### PR TITLE
Polishing up the helpers in prep for code review

### DIFF
--- a/ds3/networking/networking_test.go
+++ b/ds3/networking/networking_test.go
@@ -15,6 +15,7 @@ import (
     "testing"
     "net/url"
     "spectra/ds3_go_sdk/ds3_utils/ds3Testing"
+    "spectra/ds3_go_sdk/ds3/models"
     "strings"
 )
 
@@ -48,15 +49,14 @@ func TestBuildingAuthorizationDigestWithMetadata(t *testing.T) {
 		Proxy:       nil}
 
 	httpRequestBuilder.
-		WithHeader(AmazonMetadataPrefix + shasta, samoyed).
-		WithHeader(AmazonMetadataPrefix + gracie, eskimo).
+		WithHeader(models.AMZ_META_HEADER + shasta, samoyed).
+		WithHeader(models.AMZ_META_HEADER + gracie, eskimo).
 		Build(&connectionInfo)
 
 	amazonHeaders := httpRequestBuilder.signatureFields.CanonicalizedAmzHeaders
 
 	ds3Testing.AssertBool(t, "expected amazonHeader to have something in it", true, len(amazonHeaders) > 0)
 
-	expected := AmazonMetadataPrefix + strings.ToLower(gracie) + ":" + eskimo + "\n" + AmazonMetadataPrefix + strings.ToLower(shasta) + ":" + samoyed + "\n"
+	expected := models.AMZ_META_HEADER + strings.ToLower(gracie) + ":" + eskimo + "\n" + models.AMZ_META_HEADER + strings.ToLower(shasta) + ":" + samoyed + "\n"
 	ds3Testing.AssertBool(t, "amazonHeader string isn't what we expected", true, strings.Compare(amazonHeaders, expected) == 0)
 }
-

--- a/helpers/blobStrategy.go
+++ b/helpers/blobStrategy.go
@@ -4,19 +4,31 @@ import "time"
 
 // Strategy for how to blob objects, used both in writing and reading blob strategies
 type BlobStrategy interface {
-    delay()                      // performs delay when no job chunks are available
-    maxConcurrentTransfers() int // determines the maximum number of go routines to be created when transferring objects to/from BP
+    // performs delay when no job chunks are available
+    delay()
+
+    // determines the maximum number of go routines to be created when transferring objects to/from BP
+    maxConcurrentTransfers() uint
+
+    // determines the maximum number of blobs that are waiting to be transferred in the operations queue
+    // i.e. the size of the operation queue
+    maxWaitingTransfers() uint
 }
 
 type SimpleBlobStrategy struct {
     Delay                  time.Duration
-    MaxConcurrentTransfers int
+    MaxConcurrentTransfers uint
+    MaxWaitingTransfers    uint
 }
 
 func (strategy *SimpleBlobStrategy) delay() {
     time.Sleep(strategy.Delay)
 }
 
-func (strategy *SimpleBlobStrategy) maxConcurrentTransfers() int {
+func (strategy *SimpleBlobStrategy) maxConcurrentTransfers() uint {
     return strategy.MaxConcurrentTransfers
+}
+
+func (strategy *SimpleBlobStrategy) maxWaitingTransfers() uint {
+    return strategy.MaxWaitingTransfers
 }

--- a/helpers/helpersImpl.go
+++ b/helpers/helpersImpl.go
@@ -9,8 +9,8 @@ import (
 type HelperInterface interface {
     ListObjectsFromBucket(bucketName string) []ds3Models.S3Object
     ListObjectsFromDirectory(directoryName string) []helperModels.PutObject
-    PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (error) //todo return future
-    GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (error)   //todo return future
+    PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (error)
+    GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (error)
 }
 
 type HelperImpl struct {
@@ -33,12 +33,10 @@ func (helper *HelperImpl) ListObjectsFromDirectory(directoryName string) []helpe
 
 func (helper *HelperImpl) PutObjects(bucketName string, objects []helperModels.PutObject, strategy WriteTransferStrategy) (error) {
     transfernator := newPutTransfernator(bucketName, &objects, &strategy, helper.client)
-    err := transfernator.transfer()
-    return err
+    return transfernator.transfer()
 }
 
 func (helper *HelperImpl) GetObjects(bucketName string, objects []helperModels.GetObject, strategy ReadTransferStrategy) (error) {
     transfernator := newGetTransfernator(bucketName, &objects, &strategy, helper.client)
-    err := transfernator.transfer()
-    return err
+    return transfernator.transfer()
 }

--- a/helpers/operationQueue.go
+++ b/helpers/operationQueue.go
@@ -1,16 +1,20 @@
 package helpers
 
+import "log"
+
 type TransferOperation func() // transfer operation that sends/gets stuff from BP
 
-const MinQueueSize int = 1
-const MaxQueueSize int = 5
+const MinQueueSize uint = 1
+const MaxQueueSize uint = 100
 
-func newOperationQueue(size int) chan TransferOperation {
+func newOperationQueue(size uint) chan TransferOperation {
     var queue chan TransferOperation
 
     if size > MaxQueueSize {
+        log.Printf("WARNING Invalid operation queue size: specified value '%d' which exceeds the maximum, defaulting to '%d'\n", size, MaxQueueSize)
         queue = make(chan TransferOperation, MaxQueueSize)
     } else if size < MinQueueSize {
+        log.Printf("WARNING Invalid operation queue size: specified value '%d' which is below the minimum, defaulting to '%d'\n", size, MinQueueSize)
         queue = make(chan TransferOperation, MinQueueSize)
     } else {
         queue = make(chan TransferOperation, size)

--- a/helpers/producer.go
+++ b/helpers/producer.go
@@ -1,5 +1,7 @@
 package helpers
 
+import "spectra/ds3_go_sdk/ds3/models"
+
 type Producer interface {
-    run()
+    run(error *models.AggregateError)
 }

--- a/helpers/writeTransferStrategy.go
+++ b/helpers/writeTransferStrategy.go
@@ -4,7 +4,7 @@ import (
     "spectra/ds3_go_sdk/ds3/models"
 )
 
-var MinUploadSize int64 = 10485760 //todo move to bulk put??
+var MinUploadSize int64 = 10485760
 
 // Defines strategy for how to perform write transfers
 type WriteTransferStrategy struct {

--- a/helpers_integration/testStrategyUtils.go
+++ b/helpers_integration/testStrategyUtils.go
@@ -67,6 +67,6 @@ func newTestTransferStrategy() helpers.WriteTransferStrategy {
 // Creates a simple blob strategy for testing
 func newTestBlobStrategy() *helpers.SimpleBlobStrategy {
     var delay time.Duration = time.Second * 5
-    var maxTransferGoroutines = 5
+    var maxTransferGoroutines uint = 5
     return &helpers.SimpleBlobStrategy{Delay:delay, MaxConcurrentTransfers:maxTransferGoroutines}
 }


### PR DESCRIPTION
**Changes**
- Fixed unit test that had incorrect reference to constant due to previous code refactor
- Made `AggregateError` thread safe
- Made the size of the blob-waiting-to-be-transferred queue composable rather than rely on magic numbers
- Added AggregateError to the producer run function to ensure all errors that occur during transfer are captured. Errors are still printed to the log. Note that the `AggregateError` is passed in as a parameter since `run()` runs in a separate go routine.
- Updated queue size to be `uint` since negative numbers make no sense.